### PR TITLE
Ignore errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <name>Date Transform</name>
   <groupId>co.cask.hydrator.plugins</groupId>
   <artifactId>date-transform</artifactId>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
-    <etl.versionRange>[3.3.0,10.0.0-SNAPSHOT)</etl.versionRange>
+    <etl.versionRange>[4.1.0,4.2.0-SNAPSHOT)</etl.versionRange>
     <app.parents>
       system:cdap-etl-batch,
       system:cdap-etl-realtime,

--- a/pom.xml
+++ b/pom.xml
@@ -23,12 +23,12 @@
   <name>Date Transform</name>
   <groupId>co.cask.hydrator.plugins</groupId>
   <artifactId>date-transform</artifactId>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>3.6.0</cdap.version>
+    <cdap.version>4.1.0-SNAPSHOT</cdap.version>
     <hydrator.version>1.4.0</hydrator.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>

--- a/pom.xml
+++ b/pom.xml
@@ -23,17 +23,17 @@
   <name>Date Transform</name>
   <groupId>co.cask.hydrator.plugins</groupId>
   <artifactId>date-transform</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <packaging>jar</packaging>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <cdap.version>4.1.0-SNAPSHOT</cdap.version>
+    <cdap.version>4.1.0</cdap.version>
     <hydrator.version>1.4.0</hydrator.version>
     <!-- properties for script build step that creates the config files for the artifacts -->
     <widgets.dir>widgets</widgets.dir>
     <docs.dir>docs</docs.dir>
-    <etl.versionRange>[4.1.0,4.2.0-SNAPSHOT)</etl.versionRange>
+    <etl.versionRange>[4.1.0,5.0.0-SNAPSHOT)</etl.versionRange>
     <app.parents>
       system:cdap-etl-batch,
       system:cdap-etl-realtime,

--- a/src/test/java/co/cask/hydrator/plugin/DateTransformTest.java
+++ b/src/test/java/co/cask/hydrator/plugin/DateTransformTest.java
@@ -61,7 +61,8 @@ public class DateTransformTest {
   public void testDateTransform() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
                                                                "b", "yyyy-MM-dd",
-                                                               null, OUTPUT.toString());
+                                                               null, "No", OUTPUT.toString());
+
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
     Date date = new Date(System.currentTimeMillis());
@@ -80,7 +81,7 @@ public class DateTransformTest {
   public void testDateTransformLong() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
                                                                "b", "yyyy-MM-dd",
-                                                               "Seconds", OUTPUT.toString());
+                                                               "Seconds", "No", OUTPUT.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
 
@@ -97,7 +98,7 @@ public class DateTransformTest {
     public void testDateTransformMultipleFields() throws Exception {
         DateTransform.MyConfig config = new DateTransform.MyConfig("a,b", "MM/dd/yy",
                                                                    "c,d", "yyyy-MM-dd",
-                                                                   "Seconds", OUTPUT2.toString());
+                                                                   "Seconds", "No", OUTPUT2.toString());
         Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
         transform.initialize(null);
 
@@ -116,7 +117,7 @@ public class DateTransformTest {
   public void testSourceFormatError() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "1234sdfg",
                                                                "b", "yyyy-MM-dd",
-                                                               null, OUTPUT.toString());
+                                                               null, "No", OUTPUT.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
   }
@@ -125,7 +126,7 @@ public class DateTransformTest {
   public void testTargetFormatError() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "yyyy-MM-dd",
                                                                "b", "1234523909r",
-                                                               null, OUTPUT.toString());
+                                                               null, "No", OUTPUT.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
   }
@@ -134,7 +135,7 @@ public class DateTransformTest {
   public void testWrongFieldTransform() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
                                                                "b", "yyyy-MM-dd",
-                                                               null, OUTPUT.toString());
+                                                               null, "No", OUTPUT.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
     Date date = new Date(System.currentTimeMillis());
@@ -150,7 +151,7 @@ public class DateTransformTest {
   public void testCOnfigValidateTransform() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
                                                                "b", "yyyy-MM-dd",
-                                                               null, OUTPUT.toString());
+                                                               null, "No", OUTPUT.toString());
     config.validate(INVALID_INPUT);
   }
 
@@ -158,7 +159,7 @@ public class DateTransformTest {
   public void testDateTransformWithNullValues() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
                                                                "b", "yyyy-MM-dd",
-                                                               null, OUTPUT3.toString());
+                                                               null, "No", OUTPUT3.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
     Date date = new Date(System.currentTimeMillis());
@@ -181,7 +182,7 @@ public class DateTransformTest {
   public void testDateTransformForNullableSchema() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
                                                                "b", "yyyy-MM-dd",
-                                                               null, OUTPUT4.toString());
+                                                               null, "No", OUTPUT4.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
@@ -194,14 +195,30 @@ public class DateTransformTest {
   @Test(expected = IllegalArgumentException.class)
   public void testInvalidData() throws Exception {
     DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
-                                                               "b", "yyyy-MM-dd",
-                                                               null, OUTPUT4.toString());
+        "b", "yyyy-MM-dd",
+        null, "No", OUTPUT4.toString());
     Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
     transform.initialize(null);
     MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
     transform.transform(StructuredRecord.builder(INPUT4)
-                          .set("a", "true")
-                          .build(), emitter);
+        .set("a", "true")
+        .build(), emitter);
     Assert.fail();
+  }
+
+  @Test
+  public void testInvalidDataWithIgnoreError() throws Exception {
+    DateTransform.MyConfig config = new DateTransform.MyConfig("a", "MM/dd/yy",
+        "b", "yyyy-MM-dd",
+        null, "Yes", OUTPUT4.toString());
+    Transform<StructuredRecord, StructuredRecord> transform = new DateTransform(config);
+    transform.initialize(null);
+    MockEmitter<StructuredRecord> emitter = new MockEmitter<>();
+    transform.transform(StructuredRecord.builder(INPUT4)
+        .set("a", "true")
+        .build(), emitter);
+    Assert.assertEquals("true", emitter.getEmitted().get(0).get("b"));
+    Assert.assertEquals("true", emitter.getEmitted().get(0).get("a"));
+    Assert.assertEquals(0, emitter.getErrors().size());
   }
 }

--- a/widgets/DateTransform-transform.json
+++ b/widgets/DateTransform-transform.json
@@ -50,6 +50,15 @@
           "widget-attributes": {
             "width": "large"
           }
+        },  {
+          "widget-type": "select",
+          "label": "Ignore Errors in parsing",
+          "name": "ignoreErrors",
+          "widget-attributes": {
+            "width": "large",
+            "values": [ "Yes", "No"],
+            "default": "No"
+          }
         }
       ]
     }


### PR DESCRIPTION
There are scenarios where parsing errors should not be discarded in an error dataset. 
Ex: Excel file with date as N/A.  Adds an option to ignore parsing errors so that the data can be ingested.
